### PR TITLE
Correct library names in lib_deps

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@
 # Automatic targets - enable auto-uploading
 # targets = upload
 [platformio]
-src_dir = jump-on-it
+src_dir = jump_on_it
 
 [env:d1_mini]
 platform = espressif8266
@@ -25,8 +25,8 @@ framework = arduino
 board = d1_mini
 monitor_speed = 115200
 lib_deps =
-    Adafruit_GFX
-    Adafruit_SSD1306
+    Adafruit GFX Library
+    Adafruit SSD1306
     ArduinoJson
     ESP8266WiFi
     SPI


### PR DESCRIPTION
Incorrect name values in platformio.ini for libraries Adafruit GFX Library and Adafruit SSD1306 caused PlatformIO build to fail:
```
esp-jump-on-it/src/jump_on_it.ino:1:26: fatal error: Adafruit_GFX.h: No such file or directory
```